### PR TITLE
Separate launch file for rosbridge with authentication.

### DIFF
--- a/knowrob_roslog_launch/launch/knowrob_ease.launch
+++ b/knowrob_roslog_launch/launch/knowrob_ease.launch
@@ -1,0 +1,15 @@
+<launch>
+  <!-- KnowRob json_prolog server -->
+  <param name="initial_package" type="string" value="knowrob_roslog_launch" />
+  <param name="initial_goal" type="string" value="visualisation_canvas" />
+  <node name="json_prolog" pkg="json_prolog" type="json_prolog_node" cwd="node" output="screen" />
+
+  <param name="/ros_mac_authentication/secret_file_location" value="/etc/rosauth/secret" />
+  <node name="auth_node" pkg="rosauth" type="ros_mac_authentication" />
+  
+  <!-- rosbridge for websocket visualization -->
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
+    <arg name="authenticate" value="true"/>
+  </include>
+  
+</launch>


### PR DESCRIPTION
This launchfile enables authentication for the rosbridge node.
It is needed by the authentication enabled openEASE/webrob client.