### PR TITLE
update for IROS (warning: also change the tf data)

### DIFF
--- a/knowrob_sim/owl/knowrob_sim.owl
+++ b/knowrob_sim/owl/knowrob_sim.owl
@@ -70,11 +70,14 @@
         <rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
     </rdf:Description>
     
+
     <!-- http://knowrob.org/kb/knowrob_sim.owl#ParticleTranslation -->
+    
     <owl:Class rdf:about="&knowrob_sim;ParticleTranslation">
 		<rdfs:subClassOf rdf:resource="&knowrob;Movement-TranslationEvent"/>
 		<rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
 	</owl:Class>
+
 
     <!-- http://knowrob.org/kb/knowrob_sim.owl#Mondamin -->
 

--- a/knowrob_sim/owl/knowrob_sim.owl
+++ b/knowrob_sim/owl/knowrob_sim.owl
@@ -72,11 +72,11 @@
     
 
 
-    <!-- http://knowrob.org/kb/knowrob_sim.owl#ParticleTranslation -->
+    <!-- http://knowrob.org/kb/knowrob_sim.owl#Mondamin -->
 
-    <owl:Class rdf:about="&knowrob_sim;ParticleTranslation">
-        <rdfs:subClassOf rdf:resource="&knowrob;Movement-TranslationEvent"/>
-        <rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
+    <owl:Class rdf:about="&knowrob_sim;Mondamin">
+        <rdfs:subClassOf rdf:resource="&knowrob;Container"/>
+        <rdfs:comment>Bottle of Mondamin pancake mix</rdfs:comment>
     </owl:Class>
     
 

--- a/knowrob_sim/owl/knowrob_sim.owl
+++ b/knowrob_sim/owl/knowrob_sim.owl
@@ -70,7 +70,11 @@
         <rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
     </rdf:Description>
     
-
+    <!-- http://knowrob.org/kb/knowrob_sim.owl#ParticleTranslation -->
+    <owl:Class rdf:about="&knowrob_sim;ParticleTranslation">
+		<rdfs:subClassOf rdf:resource="&knowrob;Movement-TranslationEvent"/>
+		<rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
+	</owl:Class>
 
     <!-- http://knowrob.org/kb/knowrob_sim.owl#Mondamin -->
 

--- a/knowrob_sim/owl/knowrob_sim.owl
+++ b/knowrob_sim/owl/knowrob_sim.owl
@@ -72,11 +72,11 @@
     
 
     <!-- http://knowrob.org/kb/knowrob_sim.owl#ParticleTranslation -->
-    
+
     <owl:Class rdf:about="&knowrob_sim;ParticleTranslation">
-		<rdfs:subClassOf rdf:resource="&knowrob;Movement-TranslationEvent"/>
-		<rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
-	</owl:Class>
+        <rdfs:subClassOf rdf:resource="&knowrob;Movement-TranslationEvent"/>
+        <rdfs:subClassOf rdf:resource="&knowrob_sim;SimulationEvent"/>
+    </owl:Class>
 
 
     <!-- http://knowrob.org/kb/knowrob_sim.owl#Mondamin -->

--- a/knowrob_sim/prolog/knowrob_sim.pl
+++ b/knowrob_sim/prolog/knowrob_sim.pl
@@ -49,7 +49,7 @@
         subact/3,
         subact_all/2,
         successful_simacts_for_goal/2,
-        simflipping/9,
+        simflipping/8,
         simgrasped/4,
         add_count/1,
         experiment_file/1,
@@ -93,7 +93,7 @@
     subact_all(r,r),
     simact_start(r,r),
     simact_end(r,r),
-    simflipping(r,r,r,r,r,r,r,r,r),
+    simflipping(r,r,r,r,r,r,r,r),
     simgrasped(r,r,r,r),
     experiment_file(r),
     load_sim_experiments(r,r),
@@ -325,7 +325,7 @@ simlift_liftonly(Experiment, ObjectClass, Start, End) :-
     interval_setdifference(Experiment, TempStart, TempEnd, Candidates, Start, End).
 
 %% Flipping: grasping start until object entirely on tool, start contact tool and target, start object on tool until object back on pancakemaker, start still grasping tool until tool put down.
-simflipping(Experiment, ObjectO, ToolO, TargetO, GraspS, ToolCTargetS, ObjectLiftS, PutbackS, PutbackE) :-
+simflipping(Experiment, ObjectO, ToolO, TargetO, GraspS, ObjectLiftS, PutbackS, PutbackE) :-
     % start of GraspSpatula
     simgrasped(Experiment, Event1ID, _,ToolO),
     simact_start(Experiment, Event1ID, GraspS),
@@ -337,14 +337,10 @@ simflipping(Experiment, ObjectO, ToolO, TargetO, GraspS, ToolCTargetS, ObjectLif
     ObjectO\=TargetO,
     ToolO\=TargetO,
     %% Tool is in contact with the Object but Object has not left Target yet
-    simact_contact(Experiment, Event2ID, _, _, ToolO, ObjectO),
-    simact_start(Experiment, Event2ID, ToolCTargetS),
+    %% simact_contact(Experiment, Event2ID, _, _, ToolO, ObjectO),
+    %% simact_start(Experiment, Event2ID, ToolCTargetS),
     %% Tool is no longer in contact with the Target, but it is in contact with the Object. There is a small overlapping issue because the pancake leaves the pancakemaker a few miliseconds after the spatula does, so ObjectLiftS starts a bit before simact_end(Event0ID, End0) ends.
-    simflip_fliponly(Experiment,_,_,_,ObjectLiftS, _, ObjectO, ToolO, TargetO),
-    %% Object touches the target again
-    simact_contact(Experiment, Event3ID, _, _, ObjectO, TargetO),
-    comp_beforeI(Event2ID, Event3ID), %touches target after leaving tool
-    simact_start(Experiment, Event3ID, PutbackS). %WARNING: in old version need to cut because jsonquery backend returns all solutions, try again?
+    simflip_fliponly(Experiment,knowrob:'LiquidTangibleThing',_,_,ObjectLiftS, PutbackS, ObjectO, ToolO, TargetO).
 
 %% Gives a new interval, which is the union of contactPancake-Spatula and contactSpatula-Liquid.
 %% These two events should be overlapping in order to be a full flipping interval 
@@ -372,17 +368,16 @@ simflip_full(Experiment, ObjectClass, ToolClass, LocationClass, Start, End, OObj
 simflip_fliponly(Experiment, ObjectClass, ToolClass, LocationClass, Start, End, OObj, TObj, LObj) :-
     % get contactInterval spatula-pancakemaker
     simact_contact(Experiment, EventID, ToolClass, LocationClass, TObj, LObj),
-    % get contactInterval spatula-liquid
-    simact_contact(Experiment, EventID2, ObjectClass, ToolClass, OObj, TObj),
     %don't get the owlNamedIndividual classes
-    ObjectClass\=ToolClass,
     ToolClass\=LocationClass,
+    simact_contact(Experiment, EventID2, ObjectClass, LocationClass, OObj, LObj),
+    %% findall(EventID2, (simact_contact(Experiment, EventID2, ObjectClass, LocationClass, OObj, LObj), not(comp_temporallySubsumes(EventID2, EventID))), Candidates),
     LocationClass\=ObjectClass,
-    % these two should overlap, with the spatula-pancakemaker coming first
-    comp_overlapsI(EventID, EventID2),
+    %% [EventID2a|EventIDs] = Candidates,
     % select start and end as intersection
+    comp_beforeI(EventID,EventID2),
     simact_end(Experiment,EventID, Start),
-    simact_end(Experiment,EventID2, End).
+    simact_start(Experiment,EventID2, End).
 
 %%  simsupported(?Experiment, ?EventID, ?ObjectInstance) is 
 %   Body of the function for supported_during


### PR DESCRIPTION
Queries that work with the new pancake making data (faster than the old one).

Note that the highlighting and remove_trajectories predicates don't work as expected.