### PR TITLE
Ignoring knowrob_motion_constraints

### DIFF
--- a/knowrob_addons/package.xml
+++ b/knowrob_addons/package.xml
@@ -26,7 +26,6 @@
   <run_depend>knowrob_cad_models</run_depend>
   <run_depend>knowrob_cad_parser</run_depend>
   <run_depend>knowrob_cram</run_depend>
-  <run_depend>knowrob_motion_constraints</run_depend>
   <run_depend>knowrob_omics</run_depend>
   <run_depend>knowrob_roslog_launch</run_depend>
   <run_depend>knowrob_sim</run_depend>

--- a/knowrob_roslog_launch/CMakeLists.txt
+++ b/knowrob_roslog_launch/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(knowrob_roslog_launch)
 
-find_package(catkin REQUIRED COMPONENTS knowrob_sim knowrob_cram json_prolog knowrob_vis knowrob_meshes mjpeg_server rosbridge_server knowrob_motion_constraints knowrob_plan_summary)
+find_package(catkin REQUIRED COMPONENTS knowrob_sim knowrob_cram json_prolog knowrob_vis knowrob_meshes mjpeg_server rosbridge_server knowrob_plan_summary)
 
 
 
 catkin_package(
-    DEPENDS knowrob_sim knowrob_cram json_prolog knowrob_vis knowrob_meshes mjpeg_server rosbridge_server knowrob_motion_constraints knowrob_plan_summary
+    DEPENDS knowrob_sim knowrob_cram json_prolog knowrob_vis knowrob_meshes mjpeg_server rosbridge_server knowrob_plan_summary
 )

--- a/knowrob_roslog_launch/package.xml
+++ b/knowrob_roslog_launch/package.xml
@@ -26,7 +26,6 @@
   <build_depend>rosbridge_server</build_depend>
 <!--   <build_depend>beliefstate</build_depend> -->
 <!--   <build_depend>mongodb_log</build_depend> -->
-  <build_depend>knowrob_motion_constraints</build_depend>
   <build_depend>knowrob_plan_summary</build_depend>
 
   <run_depend>knowrob_sim</run_depend>
@@ -40,7 +39,6 @@
   <run_depend>rosbridge_server</run_depend>
 <!--   <run_depend>beliefstate</run_depend> -->
 <!--   <run_depend>mongodb_log</run_depend> -->\
-  <run_depend>knowrob_motion_constraints</run_depend>
   <run_depend>knowrob_plan_summary</run_depend>
 
 </package>

--- a/knowrob_roslog_launch/prolog/init.pl
+++ b/knowrob_roslog_launch/prolog/init.pl
@@ -41,6 +41,3 @@
 :- register_ros_package(iai_semantic_maps).
 :- register_ros_package(knowrob_srdl).
 :- register_ros_package(knowrob_plan_summary).
-% :- register_ros_package(knowrob_motion_constraints).
-
-


### PR DESCRIPTION
```knowrob_motion_constraints``` is right now not used. However, it introduces a dependency on ```knowrob_dev```. This complicates compilation of ```knowrob``` + ```knowrob_addons```. Hence, I'd like to ignore ```knowrob_motion_constraints```, for the moment. 

@daniel86 Could you please merge if this is fine with you?

For the future, I'd suggest moving ```knowrob_motion_constraints``` to a different repository.